### PR TITLE
Add missing semicolon

### DIFF
--- a/BMP280_DEV.h
+++ b/BMP280_DEV.h
@@ -195,7 +195,7 @@ class BMP280_DEV : public Device {															// Derive the BMP280_DEV class 
 				uint8_t measuring : 1;
 			} bit;
 			uint8_t reg;
-		} status = { .reg = 0 }
+		} status = { .reg = 0 };
 		
 		int32_t t_fine;																							// Bosch t_fine variable
 		int32_t bmp280_compensate_T_int32(int32_t adc_T);						// Bosch temperature compensation function


### PR DESCRIPTION
The missing semicolon caused compilation to fail:
```c++
BMP280_DEV.h:200:3: error: expected ';' before 'int32_t'

   int32_t t_fine;                       // Bosch t_fine variable
```